### PR TITLE
feat: add PR deploy previews via Cloudflare Pages

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -1,0 +1,88 @@
+name: Deploy PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  deployments: write
+
+concurrency:
+  group: preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: 0.147.6
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+
+      - name: Setup Hugo
+        run: |
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
+          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+
+      - name: Build with Hugo
+        env:
+          HUGO_ENVIRONMENT: preview
+          HUGO_ENV: preview
+        run: |
+          hugo \
+            --gc --minify \
+            --baseURL "/"
+
+      - name: Deploy to Cloudflare Pages
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy ./public --project-name=claude-docs-preview --branch=pr-${{ github.event.pull_request.number }}
+
+      - name: Post preview URL
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const deploymentUrl = '${{ steps.deploy.outputs.deployment-url }}';
+            const body = `## Deploy Preview\n\nPreview URL: ${deploymentUrl}\n\nBuilt with Hugo ${process.env.HUGO_VERSION} | Commit: ${context.sha.substring(0, 7)}`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const botComment = comments.find(c =>
+              c.user.login === 'github-actions[bot]' && c.body.includes('## Deploy Preview')
+            );
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -53,7 +53,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy ./public --project-name=claude-docs-preview --branch=pr-${{ github.event.pull_request.number }}
+          command: pages deploy ./public --project-name=claude-docs-preview --branch=pr-${{ github.event.pull_request.number }} --commit-dirty=true
 
       - name: Post preview URL
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that builds Hugo and deploys to Cloudflare Pages on every PR
- Posts a preview URL as a PR comment (upserts to avoid duplicates)
- Production deployment to GitHub Pages is unchanged

Preview URL pattern: `pr-<number>.claude-docs-preview.pages.dev`

## Test plan
- [ ] Verify the `Deploy PR Preview` workflow runs on this PR
- [ ] Check that a preview URL comment is posted
- [ ] Visit the preview URL and verify the site renders correctly
- [ ] Push another commit and verify the comment is updated (not duplicated)