### PR TITLE
Add existing codebase workflows for GSD and BMAD

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Your content starts here.
 ```
 
 - **`title`** — Page title displayed in the sidebar and browser tab.
-- **`weight`** — Controls sidebar ordering. Lower numbers appear higher. Existing pages use 1–4.
+- **`weight`** — Controls sidebar ordering. Lower numbers appear higher. Existing pages use 1–5.
 
 **Do not** add a `# Title` heading in the body — Hextra renders the `title` from front matter automatically.
 
@@ -134,6 +134,7 @@ claude-docs/
 │       ├── _index.md                # Main workshop content
 │       ├── setup-guide.md           # Pre-workshop setup
 │       ├── skills-plugins-deep-dive.md
+│       ├── existing-codebase-workflows.md
 │       └── cheat-sheet.md
 ├── static/
 │   ├── images/                      # Content images

--- a/content/_index.md
+++ b/content/_index.md
@@ -33,4 +33,10 @@ layout: hextra-home
     icon="clipboard-list"
     link="docs/cheat-sheet/"
   >}}
+  {{< hextra/feature-card
+    title="Existing Codebases"
+    subtitle="Brownfield GSD and BMAD workflows for changing an app while preserving its current patterns."
+    icon="book-open"
+    link="docs/existing-codebase-workflows/"
+  >}}
 {{< /hextra/feature-grid >}}

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -3,3 +3,15 @@ title: Documentation
 sidebar:
   open: true
 ---
+
+Workshop materials for building with Claude Code, Codex, GSD, and BMAD from the terminal.
+
+## Core Pages
+
+| Page | Use it for |
+| --- | --- |
+| [Agentic Coding in Terminal](agentic-coding-in-terminal) | Main workshop curriculum and terminal agent concepts. |
+| [Pre-Workshop Setup Guide](setup-guide) | API keys, local tools, Claude Code, Codex, and GSD setup. |
+| [Skills & Plugins Deep Dive](skills-plugins-deep-dive) | When and how to use skills, plugins, BMAD, GSD, and Superpowers. |
+| [Cheat Sheet for Claude Code](cheat-sheet) | Quick command, shortcut, and CI reference. |
+| [Existing Codebase Workflows](existing-codebase-workflows) | How to use GSD or BMAD safely in an existing application. |

--- a/content/docs/existing-codebase-workflows.md
+++ b/content/docs/existing-codebase-workflows.md
@@ -3,13 +3,9 @@ title: Existing Codebase Workflows
 weight: 5
 ---
 
-This page covers two existing-codebase workflows: GSD and BMAD.
-
-Use it when you already have an application and want an AI coding tool to change it without acting as if the repo is new.
+These are the two spec-driven frameworks we highly recommend for working with existing codebases using agentic coding tools.
 
 The goal is to give the agent enough project context to follow existing patterns, then keep the requested change small enough to review.
-
-Use the least process that still gives you enough control.
 
 Changing an existing app is different from starting with a blank repo. The agent has to preserve the code that is already there: architecture, naming patterns, tests, API contracts, database schema and migration rules, and team conventions. The more of those things a change touches, the more context and review you need before implementation.
 
@@ -24,9 +20,19 @@ For production incidents, auth, security, PII, billing, migrations, cross-repo c
 
 This guide assumes GSD or BMAD is installed, you can run the repo's checks locally, and you have permission to change the code. It does not cover starting from a blank repo, tool installation troubleshooting, or full command references.
 
+## GSD or BMAD? Or Both?
+
+From our experience using both frameworks, BMAD is very extensive for brainstorming, whether for initial brainstorming for a brand new project or to explore and discuss a new feature to be added. They have various methods for brainstorming ideas that use different brainstorming workflows and agent personas to add new POVs to build on your initial idea.
+
+The main friction with BMAD is the scoping down of workflows for the actual development parts that you have to do. This means that dev is slower as you have to manually invoke review after running the /bmad-create-story workflow, double check the story, then run /bmad-dev-story to get the agent to write the actual code, manually ask it to review, etc. The verification for each part of the workflow is manual (as of current version in Apr 2026).
+
+The frictional part of BMAD is what GSD gets right. Each step of the workflow is automatically verified and iterated by agents as part of the workflow. Code execution automatically gets verified by a code verifier agent, and it's sent back for fixes if the verification fails. This goes on in a loop until the verifier agent verifies that the code has fulfilled the requirements, where it will then proceed with the next flow.
+
+Generally, we recommend BMAD for brainstorming, and GSD for the actual code execution.
+
 ## Existing-Codebase Rule
 
-Discovery is useful, but it is not enough. Mapping and project-context steps can find existing patterns, but they cannot reliably infer project rules such as "do not touch billing", "do not change the schema", or "preserve this legacy API contract".
+Mapping and project-context steps from the two frameworks can find existing patterns, but they cannot reliably infer hidden project rules such as "do not touch billing", "do not change the schema", or "preserve this legacy API contract". These rules that apply across the codebase should live in CLAUDE.md.
 
 Before either workflow, write a short task guardrail block. This is not a codebase map. It is the boundary for the current change:
 
@@ -35,9 +41,30 @@ Before either workflow, write a short task guardrail block. This is not a codeba
 - Scope boundary: what the change should do, and what related cleanup or modernization is out of scope.
 - Verification: the exact test, lint, build, or manual checks that prove the change worked.
 
+For example:
+
+```text
+Goal:
+Add a Pause Feed action to each source row on the News Sources page.
+
+Likely area:
+News Sources table, source row actions, existing feed status API helper, related frontend tests.
+
+Hard limits:
+Do not change RSS ingestion, social media connector logic, feed parsing, database schema, auth rules, or source configuration format.
+
+Patterns to follow:
+Use the existing table action pattern, button styling, confirmation behavior, and loading/error states.
+Use the existing API helper instead of creating a second fetch path.
+
+Verify:
+Run npm test and npm run lint.
+Manually check that pausing a source updates the row state and does not delete existing articles.
+```
+
 Paste those guardrails into the workflow prompt or a small handoff file. After GSD or BMAD creates its own context artifacts, copy long-lived constraints into those artifacts and stop treating the handoff file as authoritative.
 
-## Before Either Workflow
+## Before Starting with GSD or BMAD
 
 1. Start from a clean branch.
 
@@ -48,7 +75,7 @@ git switch -c feature/my-change
 
 If `git status --short` prints anything, commit, stash, or move the work to a separate worktree before starting. Dirty changes follow you onto a new branch.
 
-2. Read the project instructions and baseline docs.
+2. Check current project instructions and baseline docs that already exist (if any).
 
 Check files such as `CLAUDE.md`, `AGENTS.md`, `README.md`, architecture notes, and nearby feature docs. Keep persistent agent instructions short and specific; do not turn `CLAUDE.md` or `AGENTS.md` into a generated codebase summary.
 
@@ -81,25 +108,6 @@ Verify:
 ```
 
 For short changes, paste this text into the workflow prompt. For longer briefs or work that needs review before execution, write a small handoff file and reference it from the prompt. Do not keep treating `task.md` as authoritative after GSD or BMAD creates its own artifacts.
-
-```text
-Goal:
-Add a Pause Feed action to each source row on the News Sources page.
-
-Likely area:
-News Sources table, source row actions, existing feed status API helper, related frontend tests.
-
-Hard limits:
-Do not change RSS ingestion, social media connector logic, feed parsing, database schema, auth rules, or source configuration format.
-
-Patterns to follow:
-Use the existing table action pattern, button styling, confirmation behavior, and loading/error states.
-Use the existing API helper instead of creating a second fetch path.
-
-Verify:
-Run npm test and npm run lint.
-Manually check that pausing a source updates the row state and does not delete existing articles.
-```
 
 ## Choose GSD or BMAD
 

--- a/content/docs/existing-codebase-workflows.md
+++ b/content/docs/existing-codebase-workflows.md
@@ -1,0 +1,219 @@
+---
+title: Existing Codebase Workflows
+weight: 5
+---
+
+Use this when you already have an application and want Claude Code to make a change without treating the repo like a blank project.
+
+The goal is to give the agent enough project context to follow existing patterns, then keep the requested change small enough to review.
+
+## Before Either Workflow
+
+1. Start from a clean git branch.
+
+```bash
+git status
+git switch -c feature/my-change
+```
+
+2. Read the existing docs and run the baseline checks.
+
+```bash
+# Examples only. Use the commands from the repo you are working in.
+npm test
+npm run lint
+```
+
+3. Write the task in one or two sentences.
+
+Good brownfield tasks name the user-facing change, the files or area likely involved, the constraints, and the verification command.
+
+```text
+Add a Test action to each collector row on the Settings page.
+The backend route and API helper already exist, so do not change the database or backend contract.
+Follow the current table and button patterns. Verify with npm test and npm run lint.
+```
+
+## GSD Path
+
+Use GSD when you want the change to be tracked through requirements, phases, plans, execution, and verification.
+
+### 1. Map the Current Codebase
+
+Run the mapper before initializing GSD for an existing app:
+
+```text
+/gsd-map-codebase
+```
+
+Review the generated `.planning/codebase/` files. Check that the stack, major directories, test commands, and risk areas match the repo.
+
+For a quick first pass, use:
+
+```text
+/gsd-scan
+/gsd-scan --focus concerns
+```
+
+### 2. Initialize Around What You Are Adding
+
+Then create the GSD project context:
+
+```text
+/gsd-new-project
+```
+
+When answering prompts, frame the work as a change to an existing application. Point GSD at the codebase map and existing docs. Keep unrelated cleanup, rewrites, and "while you are there" ideas out of the first milestone.
+
+### 3. Pick the Smallest GSD Flow That Fits
+
+For a small bug fix or narrow UI/API change:
+
+```text
+/gsd-quick
+```
+
+If the change still needs stronger checks:
+
+```text
+/gsd-quick --validate
+/gsd-quick --research --validate
+```
+
+For a larger feature, use the full phase flow:
+
+```text
+/gsd-discuss-phase 1
+/gsd-plan-phase 1
+/gsd-execute-phase 1
+/gsd-verify-work 1
+/gsd-ship 1
+```
+
+Use discussion mode when you want to answer design and implementation questions yourself. If the repo has strong conventions and you want GSD to infer them first, set assumptions mode:
+
+```text
+/gsd-settings workflow.discuss_mode assumptions
+/gsd-discuss-phase 1
+```
+
+### 4. Review the Artifacts Before Code
+
+Before execution, inspect:
+
+```text
+.planning/PROJECT.md
+.planning/REQUIREMENTS.md
+.planning/ROADMAP.md
+.planning/phases/
+```
+
+The plan should say what will change, what will not change, which tests will run, and which existing patterns it will follow.
+
+### 5. Verify and Refresh Context
+
+After execution, run the repo checks yourself and inspect the diff:
+
+```bash
+git diff
+git status
+```
+
+If the phase creates new route folders, migrations, module boundaries, or other structural changes, refresh the codebase map before planning the next phase:
+
+```text
+/gsd-map-codebase
+```
+
+## BMAD Path
+
+Use BMAD when you want a product/team-style workflow with role-specific agents, project context, PRDs, architecture notes, stories, implementation, and review.
+
+BMAD installs can expose workflows as skills or slash commands depending on the runtime and install version. If your generated BMAD items are skills, type `bmad-quick-dev`. If your workshop setup exposes slash commands, type `/bmad-quick-dev`. The workflow names are otherwise the same.
+
+### 1. Generate Project Context
+
+Install BMAD in the repo if it is not already installed:
+
+```bash
+npx bmad-method install
+```
+
+Then generate the project context:
+
+```text
+/bmad-generate-project-context
+```
+
+Review `_bmad-output/project-context.md`. It should capture the stack, versions, folder conventions, test commands, styling rules, and implementation constraints that the agents should follow.
+
+Edit this file before implementation if it misses a rule the project depends on.
+
+For a complex or poorly documented app, also consider:
+
+```text
+/bmad-document-project
+```
+
+Use that when BMAD needs a current-state project document before it can safely plan against the existing system.
+
+### 2. Pick Quick Dev or the Full Method
+
+For a small fix, refactor, or narrow feature:
+
+```text
+/bmad-quick-dev
+```
+
+Give it the same kind of constrained brownfield task you would give a developer:
+
+```text
+Use the existing Settings table patterns to add a Test action to each collector row.
+Do not change backend routes, database schema, or collector configuration format.
+Run the existing frontend checks before summarizing.
+```
+
+For larger product work, use the full planning path:
+
+```text
+/bmad-product-brief
+/bmad-create-prd
+/bmad-create-architecture
+/bmad-create-epics-and-stories
+/bmad-sprint-planning
+/bmad-create-story
+/bmad-dev-story
+/bmad-code-review
+```
+
+### 3. Keep BMAD Grounded in Existing Patterns
+
+Before accepting a story or implementation, check that the artifact names the existing modules, contracts, and tests it will preserve.
+
+If BMAD proposes a modernization you did not ask for, stop and restate the boundary:
+
+```text
+Keep this as a brownfield change. Follow the existing service/component pattern even if a different architecture would be cleaner. Do not rewrite unrelated files.
+```
+
+### 4. Review Outputs and Promote Only What Matters
+
+BMAD writes working files under `_bmad-output/`. Treat that folder as a working notebook, not automatically as permanent docs.
+
+Promote or rewrite an artifact into your normal docs only when it records a long-term decision. Otherwise, review it, use it for the change, and keep the PR focused on the product/code diff.
+
+## Choosing Between Them
+
+| Situation | Better fit |
+| --- | --- |
+| Small bug fix with light tracking | GSD quick or BMAD quick-dev |
+| Existing app needs phased delivery and verification | GSD |
+| Product-heavy change with PRD, architecture, stories, and review | BMAD |
+| Team wants durable phase state in git | GSD |
+| Team wants role-specific planning artifacts | BMAD |
+
+For either tool, the brownfield rule is the same: make the agent discover the current system first, constrain the requested change, then review generated artifacts before letting it edit broadly.
+
+---
+
+[Back to main page](/)

--- a/content/docs/existing-codebase-workflows.md
+++ b/content/docs/existing-codebase-workflows.md
@@ -7,6 +7,14 @@ Use this when you already have an application and want Claude Code to make a cha
 
 The goal is to give the agent enough project context to follow existing patterns, then keep the requested change small enough to review.
 
+Official references worth reading alongside this page:
+
+| Tool | Reference |
+| --- | --- |
+| GSD v1 | [Brownfield Projects](https://mintlify.wiki/gsd-build/get-shit-done/guides/brownfield-projects) |
+| GSD 2 | [Brownfield Reality](https://getshitdone.help/solo-guide/brownfield/) |
+| BMAD | [Established Projects](https://docs.bmad-method.org/how-to/established-projects/) |
+
 ## Before Either Workflow
 
 1. Start from a clean git branch.
@@ -37,6 +45,8 @@ Follow the current table and button patterns. Verify with npm test and npm run l
 ## GSD Path
 
 Use GSD when you want the change to be tracked through requirements, phases, plans, execution, and verification.
+
+GSD command names vary by install and runtime. Some setups use `/gsd-map-codebase`; others expose the same command as `/gsd:map-codebase`. Run `/gsd-help` or `/gsd:help` and use the names shown in your session.
 
 ### 1. Map the Current Codebase
 

--- a/content/docs/existing-codebase-workflows.md
+++ b/content/docs/existing-codebase-workflows.md
@@ -3,28 +3,56 @@ title: Existing Codebase Workflows
 weight: 5
 ---
 
-Use this when you already have an application and want Claude Code to make a change without treating the repo like a blank project.
+This page covers two existing-codebase workflows: GSD and BMAD.
+
+Use it when you already have an application and want an AI coding tool to change it without acting as if the repo is new.
 
 The goal is to give the agent enough project context to follow existing patterns, then keep the requested change small enough to review.
 
-Official references worth reading alongside this page:
+Use the least process that still gives you enough control.
 
-| Tool | Reference |
-| --- | --- |
-| GSD v1 | [Brownfield Projects](https://mintlify.wiki/gsd-build/get-shit-done/guides/brownfield-projects) |
-| GSD 2 | [Brownfield Reality](https://getshitdone.help/solo-guide/brownfield/) |
-| BMAD | [Established Projects](https://docs.bmad-method.org/how-to/established-projects/) |
+Changing an existing app is different from starting with a blank repo. The agent has to preserve the code that is already there: architecture, naming patterns, tests, API contracts, database schema and migration rules, and team conventions. The more of those things a change touches, the more context and review you need before implementation.
+
+There are four levels:
+
+- **Plain session**: use Claude Code or Codex directly for a typo, copy edit, simple test update, or one-file fix where you already know the right file and expected diff.
+- **Quick workflow**: use GSD quick or BMAD quick-dev when the change is small but still needs repo discovery, guardrails, or light tracking.
+- **Full GSD path**: use GSD's map, project, spec, discuss, plan, execute, verify, review, and ship flow when the work should be tracked through phases and verification.
+- **Full BMAD path**: use BMAD's project-context, brief, PRD, architecture, story, implementation, and review flow when the work needs product/team-style artifacts.
+
+For production incidents, auth, security, PII, billing, migrations, cross-repo changes, ambiguous requirements, or substantial business logic, do not use quick mode. Use the full GSD or full BMAD path and manually review the generated artifacts, planned commands, and final diff.
+
+This guide assumes GSD or BMAD is installed, you can run the repo's checks locally, and you have permission to change the code. It does not cover starting from a blank repo, tool installation troubleshooting, or full command references.
+
+## Existing-Codebase Rule
+
+Discovery is useful, but it is not enough. Mapping and project-context steps can find existing patterns, but they cannot reliably infer project rules such as "do not touch billing", "do not change the schema", or "preserve this legacy API contract".
+
+Before either workflow, write a short task guardrail block. This is not a codebase map. It is the boundary for the current change:
+
+- Hard limits: files, schemas, APIs, subsystems, or behaviors that must not change without explicit approval.
+- Patterns to follow: existing route, component, service, test, styling, or error-handling examples.
+- Scope boundary: what the change should do, and what related cleanup or modernization is out of scope.
+- Verification: the exact test, lint, build, or manual checks that prove the change worked.
+
+Paste those guardrails into the workflow prompt or a small handoff file. After GSD or BMAD creates its own context artifacts, copy long-lived constraints into those artifacts and stop treating the handoff file as authoritative.
 
 ## Before Either Workflow
 
-1. Start from a clean git branch.
+1. Start from a clean branch.
 
 ```bash
-git status
+git status --short
 git switch -c feature/my-change
 ```
 
-2. Read the existing docs and run the baseline checks.
+If `git status --short` prints anything, commit, stash, or move the work to a separate worktree before starting. Dirty changes follow you onto a new branch.
+
+2. Read the project instructions and baseline docs.
+
+Check files such as `CLAUDE.md`, `AGENTS.md`, `README.md`, architecture notes, and nearby feature docs. Keep persistent agent instructions short and specific; do not turn `CLAUDE.md` or `AGENTS.md` into a generated codebase summary.
+
+3. Run the baseline checks.
 
 ```bash
 # Examples only. Use the commands from the repo you are working in.
@@ -32,52 +60,87 @@ npm test
 npm run lint
 ```
 
-3. Write the task in one or two sentences.
+If the baseline already fails, record the failure before asking the agent to work. That gives you something to compare against after implementation.
 
-Good brownfield tasks name the user-facing change, the files or area likely involved, the constraints, and the verification command.
+4. Start a fresh agent session for the change.
 
-```text
-Add a Test action to each collector row on the Settings page.
-The backend route and API helper already exist, so do not change the database or backend contract.
-Follow the current table and button patterns. Verify with npm test and npm run lint.
-```
+Reusing a long or unrelated session makes it easier for old assumptions to leak into the work.
 
-## GSD Path
+5. Write the task in one or two sentences.
 
-Use GSD when you want the change to be tracked through requirements, phases, plans, execution, and verification.
+A useful existing-codebase task names the user-facing change, likely files or areas, constraints, and verification command.
 
-GSD command names vary by install and runtime. Some setups use `/gsd-map-codebase`; others expose the same command as `/gsd:map-codebase`. Run `/gsd-help` or `/gsd:help` and use the names shown in your session.
-
-### 1. Map the Current Codebase
-
-Run the mapper before initializing GSD for an existing app:
+Use this shape:
 
 ```text
-/gsd-map-codebase
+Goal:
+Likely area:
+Hard limits:
+Patterns to follow:
+Verify:
 ```
 
-Review the generated `.planning/codebase/` files. Check that the stack, major directories, test commands, and risk areas match the repo.
-
-For a quick first pass, use:
+For short changes, paste this text into the workflow prompt. For longer briefs or work that needs review before execution, write a small handoff file and reference it from the prompt. Do not keep treating `task.md` as authoritative after GSD or BMAD creates its own artifacts.
 
 ```text
-/gsd-scan
-/gsd-scan --focus concerns
+Goal:
+Add a Pause Feed action to each source row on the News Sources page.
+
+Likely area:
+News Sources table, source row actions, existing feed status API helper, related frontend tests.
+
+Hard limits:
+Do not change RSS ingestion, social media connector logic, feed parsing, database schema, auth rules, or source configuration format.
+
+Patterns to follow:
+Use the existing table action pattern, button styling, confirmation behavior, and loading/error states.
+Use the existing API helper instead of creating a second fetch path.
+
+Verify:
+Run npm test and npm run lint.
+Manually check that pausing a source updates the row state and does not delete existing articles.
 ```
 
-### 2. Initialize Around What You Are Adding
+## Choose GSD or BMAD
 
-Then create the GSD project context:
+| Situation | Better fit |
+| --- | --- |
+| Typo, copy edit, obvious one-file fix | Plain Claude Code or Codex |
+| Small bug fix with light tracking | GSD quick or BMAD quick-dev |
+| Existing app needs phased delivery and verification | Full GSD path |
+| Product-heavy change with PRD, architecture, stories, and review | BMAD |
+| Team wants durable phase state in git | Full GSD path |
+| Team wants role-specific planning artifacts | BMAD |
+| Auth, security, PII, billing, migrations, incidents, or ambiguous requirements | Full GSD or full BMAD path plus manual review |
+
+For either tool, start with discovery, constrain the change, and review generated artifacts before allowing large edits.
+
+## Command Names Vary
+
+The examples below use Claude Code slash-command style.
+
+| Tool | Examples |
+| --- | --- |
+| GSD | `/gsd-help`, `/gsd-map-codebase`, `/gsd-quick` |
+| BMAD | `/bmad-help`, `/bmad-generate-project-context`, `/bmad-quick-dev` |
+
+In Codex, GSD skills use `$` instead of `/`, such as `$gsd-help` or `$gsd-quick`. If a command is not found, run the tool's help command and use the syntax shown in your session. Also use the output folders created by your install; examples here use the common defaults.
+
+## Use GSD
+
+Use GSD when you want requirements, phases, plans, execution, and verification tracked in git.
+
+Start with help:
 
 ```text
-/gsd-new-project
+/gsd-help
 ```
 
-When answering prompts, frame the work as a change to an existing application. Point GSD at the codebase map and existing docs. Keep unrelated cleanup, rewrites, and "while you are there" ideas out of the first milestone.
+Use the command names your session shows.
 
-### 3. Pick the Smallest GSD Flow That Fits
+### 1. Pick the Smallest GSD Flow That Fits
 
-For a small bug fix or narrow UI/API change:
+For a small bug fix or narrow UI/API change, use quick work. If you already know the files and constraints, paste the task and guardrails directly into:
 
 ```text
 /gsd-quick
@@ -90,24 +153,49 @@ If the change still needs stronger checks:
 /gsd-quick --research --validate
 ```
 
-For a larger feature, use the full phase flow:
+If you need a fast read on an unfamiliar area before quick work, use scan:
 
 ```text
-/gsd-discuss-phase 1
-/gsd-plan-phase 1
-/gsd-execute-phase 1
-/gsd-verify-work 1
-/gsd-ship 1
+/gsd-scan
+/gsd-scan --focus concerns
 ```
 
-Use discussion mode when you want to answer design and implementation questions yourself. If the repo has strong conventions and you want GSD to infer them first, set assumptions mode:
+### 2. Map Before Full Project Setup
+
+For larger existing-codebase work, map the repo before creating GSD project context:
+
+```text
+/gsd-map-codebase
+```
+
+Review the generated `.planning/codebase/` files. Check that the stack, major directories, test commands, and risk areas match the repo. Fix obvious wrong assumptions before planning from the map.
+
+### 3. Initialize Project Context
+
+Then create the GSD project context:
+
+```text
+/gsd-new-project
+```
+
+When answering prompts, frame the work as a change to an existing application. Point GSD at the codebase map and existing docs. Keep unrelated cleanup and rewrites out of the first milestone.
+
+Use discussion mode when you want to answer design and implementation questions yourself. Use assumptions mode when you want GSD to inspect the repo and propose defaults first:
 
 ```text
 /gsd-settings workflow.discuss_mode assumptions
 /gsd-discuss-phase 1
 ```
 
-### 4. Review the Artifacts Before Code
+Then use the full GSD path:
+
+```text
+/gsd-spec-phase 1
+/gsd-discuss-phase 1
+/gsd-plan-phase 1
+```
+
+### 4. Review Artifacts Before Code
 
 Before execution, inspect:
 
@@ -120,14 +208,30 @@ Before execution, inspect:
 
 The plan should say what will change, what will not change, which tests will run, and which existing patterns it will follow.
 
+After review, continue with implementation:
+
+```text
+/gsd-execute-phase 1
+/gsd-verify-work 1
+/gsd-code-review 1
+/gsd-ship 1
+```
+
+This sequence is for the first GSD run in a repo. If `.planning/` already exists, refresh `/gsd-map-codebase` when needed, then continue with the next phase instead of running `/gsd-new-project` again.
+
 ### 5. Verify and Refresh Context
 
-After execution, run the repo checks yourself and inspect the diff:
+After execution, rerun the repo checks yourself and inspect the diff:
 
 ```bash
+# Use the repo's real commands.
+npm test
+npm run lint
 git diff
 git status
 ```
+
+Compare the result with any baseline failures you recorded before the change.
 
 If the phase creates new route folders, migrations, module boundaries, or other structural changes, refresh the codebase map before planning the next phase:
 
@@ -135,11 +239,17 @@ If the phase creates new route folders, migrations, module boundaries, or other 
 /gsd-map-codebase
 ```
 
-## BMAD Path
+## Use BMAD
 
-Use BMAD when you want a product/team-style workflow with role-specific agents, project context, PRDs, architecture notes, stories, implementation, and review.
+Use BMAD when you want role-specific planning artifacts: project context, PRDs, architecture notes, stories, implementation, and review.
 
-BMAD installs can expose workflows as skills or slash commands depending on the runtime and install version. If your generated BMAD items are skills, type `bmad-quick-dev`. If your workshop setup exposes slash commands, type `/bmad-quick-dev`. The workflow names are otherwise the same.
+Start with help:
+
+```text
+/bmad-help
+```
+
+Use the command names your session shows.
 
 ### 1. Generate Project Context
 
@@ -149,23 +259,25 @@ Install BMAD in the repo if it is not already installed:
 npx bmad-method install
 ```
 
+If the repo already has BMAD output from finished or stale work, archive or clean it before starting a new change.
+
 Then generate the project context:
 
 ```text
 /bmad-generate-project-context
 ```
 
-Review `_bmad-output/project-context.md`. It should capture the stack, versions, folder conventions, test commands, styling rules, and implementation constraints that the agents should follow.
+Review the configured BMAD output folder, commonly `_bmad-output/`. Its `project-context.md` should capture the stack, versions, folder conventions, test commands, styling rules, and implementation constraints that the agents should follow.
 
-Edit this file before implementation if it misses a rule the project depends on.
+Edit this file before implementation if it misses a rule the project depends on. Remove generic advice that does not change how this project should be built.
 
-For a complex or poorly documented app, also consider:
+For a complex or poorly documented app, run:
 
 ```text
 /bmad-document-project
 ```
 
-Use that when BMAD needs a current-state project document before it can safely plan against the existing system.
+Use that when BMAD needs a current-state project document before planning changes.
 
 ### 2. Pick Quick Dev or the Full Method
 
@@ -175,7 +287,7 @@ For a small fix, refactor, or narrow feature:
 /bmad-quick-dev
 ```
 
-Give it the same kind of constrained brownfield task you would give a developer:
+Give it the same kind of constrained existing-codebase task you would give a developer:
 
 ```text
 Use the existing Settings table patterns to add a Test action to each collector row.
@@ -183,18 +295,19 @@ Do not change backend routes, database schema, or collector configuration format
 Run the existing frontend checks before summarizing.
 ```
 
-For larger product work, use the full planning path:
+For larger product work, use the full BMAD path. In this page, that means generating project context first, then running the product/story flow:
 
 ```text
+/bmad-brainstorming
 /bmad-product-brief
 /bmad-create-prd
 /bmad-create-architecture
 /bmad-create-epics-and-stories
 /bmad-sprint-planning
 /bmad-create-story
-/bmad-dev-story
-/bmad-code-review
 ```
+
+Skip `/bmad-brainstorming` when the change is already defined and you do not need idea exploration.
 
 ### 3. Keep BMAD Grounded in Existing Patterns
 
@@ -203,26 +316,46 @@ Before accepting a story or implementation, check that the artifact names the ex
 If BMAD proposes a modernization you did not ask for, stop and restate the boundary:
 
 ```text
-Keep this as a brownfield change. Follow the existing service/component pattern even if a different architecture would be cleaner. Do not rewrite unrelated files.
+Keep this as an existing-codebase change. Follow the existing service/component pattern even if a different architecture would be cleaner. Do not rewrite unrelated files.
+```
+
+After review, continue with implementation:
+
+```text
+/bmad-dev-story
+/bmad-code-review
 ```
 
 ### 4. Review Outputs and Promote Only What Matters
 
-BMAD writes working files under `_bmad-output/`. Treat that folder as a working notebook, not automatically as permanent docs.
+BMAD writes working files under its configured output folder, commonly `_bmad-output/`. Treat those files as working material, not permanent documentation by default.
 
 Promote or rewrite an artifact into your normal docs only when it records a long-term decision. Otherwise, review it, use it for the change, and keep the PR focused on the product/code diff.
 
-## Choosing Between Them
+## Final Review Checklist
 
-| Situation | Better fit |
+Before shipping the change, confirm:
+
+- Generated context, plans, stories, or reviews were read and corrected.
+- Tests, lint, build, and manual checks from the guardrail block were rerun.
+- The diff is limited to the expected files and behavior.
+- No hard-limit files, schemas, APIs, or contracts changed without approval.
+- Baseline failures are unchanged or clearly explained.
+- New structural changes are reflected in the next codebase map or project context refresh.
+
+## Official References
+
+Official references worth reading alongside this page:
+
+| Tool | Reference |
 | --- | --- |
-| Small bug fix with light tracking | GSD quick or BMAD quick-dev |
-| Existing app needs phased delivery and verification | GSD |
-| Product-heavy change with PRD, architecture, stories, and review | BMAD |
-| Team wants durable phase state in git | GSD |
-| Team wants role-specific planning artifacts | BMAD |
+| GSD | [Brownfield Projects](https://mintlify.wiki/gsd-build/get-shit-done/guides/brownfield-projects) |
+| BMAD | [Established Projects](https://docs.bmad-method.org/how-to/established-projects/) |
+| BMAD | [Project Context](https://docs.bmad-method.org/explanation/project-context/) |
+| BMAD | [Commands and Skills](https://docs.bmad-method.org/reference/commands/) |
+| Claude Code | [Skills and Custom Commands](https://code.claude.com/docs/en/slash-commands) |
 
-For either tool, the brownfield rule is the same: make the agent discover the current system first, constrain the requested change, then review generated artifacts before letting it edit broadly.
+Related GSD 2 reading: [Brownfield Reality](https://getshitdone.help/solo-guide/brownfield/) and [Context Engineering](https://getshitdone.help/solo-guide/context-engineering/). GSD 2 has useful brownfield concepts, but its command syntax and project structure differ from the GSD workflow shown above.
 
 ---
 

--- a/content/docs/existing-codebase-workflows.md
+++ b/content/docs/existing-codebase-workflows.md
@@ -7,18 +7,16 @@ These are the two spec-driven frameworks we highly recommend for working with ex
 
 The goal is to give the agent enough project context to follow existing patterns, then keep the requested change small enough to review.
 
-Changing an existing app is different from starting with a blank repo. The agent has to preserve the code that is already there: architecture, naming patterns, tests, API contracts, database schema and migration rules, and team conventions. The more of those things a change touches, the more context and review you need before implementation.
+Existing apps already have architecture, naming patterns, tests, API contracts, database rules, and team habits. The agent needs those boundaries before it edits.
 
-There are four levels:
+Pick the lightest workflow that fits the task. Choose a heavier workflow as complexity grows: more brainstorming, larger features, more repo context, review, or verification:
 
 - **Plain session**: use Claude Code or Codex directly for a typo, copy edit, simple test update, or one-file fix where you already know the right file and expected diff.
 - **Quick workflow**: use `gsd-quick` or `bmad-quick-dev` when the change is small but still needs repo discovery, guardrails, or light tracking.
 - **Full GSD path**: use GSD's map, project, spec, discuss, plan, execute, verify, review, and ship flow when the work should be tracked through phases and verification.
-- **Full BMAD path**: use BMAD's project-context, brief, PRD, architecture, story, implementation, and review flow when the work needs product/team-style artifacts.
+- **Full BMAD path**: use BMAD's project-context, brief, PRD, architecture, story, implementation, and review flow when the work needs product planning and handoffs.
 
-For production incidents, auth, security, PII, billing, migrations, cross-repo changes, ambiguous requirements, or substantial business logic, do not use quick mode. Use the full GSD or full BMAD path and manually review the generated artifacts, planned commands, and final diff.
-
-This guide assumes GSD or BMAD is installed, you can run the repo's checks locally, and you have permission to change the code. It does not cover starting from a blank repo, tool installation troubleshooting, or full command references.
+This guide assumes GSD or BMAD is installed, you can run the repo's checks locally, and you have permission to change the code. It does not cover blank projects, install troubleshooting, or full command references.
 
 ## GSD or BMAD? Or Both?
 
@@ -32,7 +30,7 @@ Generally, we recommend BMAD for brainstorming, and GSD for the actual code exec
 
 ## Existing-Codebase Rule
 
-Mapping and project-context steps from the two frameworks can find existing patterns, but they cannot reliably infer hidden project rules such as "do not touch billing", "do not change the schema", or "preserve this legacy API contract". These rules that apply across the codebase should live in CLAUDE.md.
+Mapping and project-context steps can find existing patterns, but they cannot infer hidden project rules such as "do not touch IAM", "do not change the schema", or "preserve this legacy API contract". Rules that apply across the codebase should live in `CLAUDE.md`.
 
 Before either workflow, write a short task guardrail block. This is not a codebase map. It is the boundary for the current change:
 
@@ -45,24 +43,24 @@ For example:
 
 ```text
 Goal:
-Add a Pause Feed action to each source row on the News Sources page.
+Add a Refresh Feed button to each source row on the News Sources page.
 
 Likely area:
-News Sources table, source row actions, existing feed status API helper, related frontend tests.
+News Sources table, source row actions, existing feed refresh API helper, related frontend tests.
 
 Hard limits:
-Do not change RSS ingestion, social media connector logic, feed parsing, database schema, auth rules, or source configuration format.
+Do not change feed parsing, database schema, auth rules, or source configuration format.
 
 Patterns to follow:
-Use the existing table action pattern, button styling, confirmation behavior, and loading/error states.
+Use the existing table action pattern, button styling, loading state, and error handling.
 Use the existing API helper instead of creating a second fetch path.
 
 Verify:
 Run npm test and npm run lint.
-Manually check that pausing a source updates the row state and does not delete existing articles.
+Manually check that refreshing a source updates the row status and does not delete existing articles.
 ```
 
-Paste those guardrails into the workflow prompt or a small handoff file. After GSD or BMAD creates its own context artifacts, copy long-lived constraints into those artifacts and stop treating the handoff file as authoritative.
+Paste those guardrails into the workflow prompt or a small handoff file. After GSD or BMAD creates planning files, move any long-lived constraints there and stop treating the handoff file as authoritative.
 
 ## Before Starting with GSD or BMAD
 
@@ -77,7 +75,7 @@ If `git status --short` prints anything, commit, stash, or move the work to a se
 
 2. Check current project instructions and baseline docs that already exist (if any).
 
-Check files such as `CLAUDE.md`, `AGENTS.md`, `README.md`, architecture notes, and nearby feature docs. Keep persistent agent instructions short and specific; do not turn `CLAUDE.md` or `AGENTS.md` into a generated codebase summary.
+Check files such as `CLAUDE.md`, `AGENTS.md`, `README.md`, architecture notes, and nearby feature docs. Keep persistent agent instructions short and specific. Do not turn `CLAUDE.md` or `AGENTS.md` into a generated codebase summary. For examples, see [CLAUDE.md and AGENTS.md](agentic-coding-in-terminal#claudemd-and-agentsmd).
 
 3. Run the baseline checks.
 
@@ -95,7 +93,7 @@ Reusing a long or unrelated session makes it easier for old assumptions to leak 
 
 5. Write the task in one or two sentences.
 
-A useful existing-codebase task names the user-facing change, likely files or areas, constraints, and verification command.
+A good existing-codebase task names the user-facing change, likely files or areas, hard limits, and verification command.
 
 Use this shape:
 
@@ -107,21 +105,21 @@ Patterns to follow:
 Verify:
 ```
 
-For short changes, paste this text into the workflow prompt. For longer briefs or work that needs review before execution, write a small handoff file and reference it from the prompt. Do not keep treating `task.md` as authoritative after GSD or BMAD creates its own artifacts.
+For short changes, paste this text into the workflow prompt. For longer briefs, write a small handoff file and reference it from the prompt. Once GSD or BMAD creates planning files, update those files instead of keeping a separate `task.md`.
 
-## Choose GSD or BMAD
+## Choose the Workflow
 
-| Situation | Better fit |
+| Situation | Use |
 | --- | --- |
 | Typo, copy edit, obvious one-file fix | Plain Claude Code or Codex |
 | Small bug fix with light tracking | `gsd-quick` or `bmad-quick-dev` |
+| Feature idea still needs brainstorming or product shape | BMAD |
+| Product-heavy change needs a PRD, architecture notes, or stories | BMAD first, then GSD for execution |
 | Existing app needs phased delivery and verification | Full GSD path |
-| Product-heavy change with PRD, architecture, stories, and review | BMAD |
-| Team wants durable phase state in git | Full GSD path |
-| Team wants role-specific planning artifacts | BMAD |
-| Auth, security, PII, billing, migrations, incidents, or ambiguous requirements | Full GSD or full BMAD path plus manual review |
+| Team wants planning split by product, architect, and dev roles | BMAD |
+| Auth, security, PII, billing, migrations, incidents, or unclear requirements | Full GSD or full BMAD path plus manual review |
 
-For either tool, start with discovery, constrain the change, and review generated artifacts before allowing large edits.
+For either tool, start with discovery, set clear boundaries, and review the planning files it writes before allowing large edits.
 
 ## Command Names Vary
 
@@ -136,7 +134,9 @@ In Codex, GSD skills use `$` instead of `/`, such as `$gsd-help` or `$gsd-quick`
 
 ## Use GSD
 
-Use GSD when you want requirements, phases, plans, execution, and verification tracked in git.
+Use GSD when the change is defined and you want requirements, plans, execution, and verification tracked in git.
+
+If BMAD already produced a brief, PRD, architecture notes, or stories, use those as inputs to GSD. Do not brainstorm the same feature again.
 
 Start with help:
 
@@ -154,14 +154,14 @@ For a small bug fix or narrow UI/API change, use quick work. If you already know
 /gsd-quick
 ```
 
-If the change still needs stronger checks:
+When quick work still needs validation, add the relevant phase flag:
 
 ```text
 /gsd-quick --validate
 /gsd-quick --research --validate
 ```
 
-If you need a fast read on an unfamiliar area before quick work, use scan:
+When you need a fast read on an unfamiliar area before quick work, use scan:
 
 ```text
 /gsd-scan
@@ -170,13 +170,13 @@ If you need a fast read on an unfamiliar area before quick work, use scan:
 
 ### 2. Map Before Full Project Setup
 
-For larger existing-codebase work, map the repo before creating GSD project context:
+For larger work, map the repo before creating GSD project context:
 
 ```text
 /gsd-map-codebase
 ```
 
-Review the generated `.planning/codebase/` files. Check that the stack, major directories, test commands, and risk areas match the repo. Fix obvious wrong assumptions before planning from the map.
+Open `.planning/codebase/` and check the stack, major directories, test commands, and risk areas. Fix obvious wrong assumptions before planning from the map.
 
 ### 3. Initialize Project Context
 
@@ -203,7 +203,7 @@ Then use the full GSD path:
 /gsd-plan-phase 1
 ```
 
-### 4. Review Artifacts Before Code
+### 4. Review the Plan Before Code
 
 Before execution, inspect:
 
@@ -214,7 +214,7 @@ Before execution, inspect:
 .planning/phases/
 ```
 
-The plan should say what will change, what will not change, which tests will run, and which existing patterns it will follow.
+The plan should say what will change, what will not change, how the work is split across phases, which tests will run, and which existing patterns it will follow.
 
 After review, continue with implementation:
 
@@ -225,7 +225,7 @@ After review, continue with implementation:
 /gsd-ship 1
 ```
 
-This sequence is for the first GSD run in a repo. If `.planning/` already exists, refresh `/gsd-map-codebase` when needed, then continue with the next phase instead of running `/gsd-new-project` again.
+The sequence above is for the first GSD run in a repo. If GSD has already been initialized, refresh the map with `/gsd-map-codebase` when needed, then continue with the next phase. Do not run `/gsd-new-project` again unless the project state is missing or stale enough to rebuild.
 
 ### 5. Verify and Refresh Context
 
@@ -249,7 +249,7 @@ If the phase creates new route folders, migrations, module boundaries, or other 
 
 ## Use BMAD
 
-Use BMAD when you want role-specific planning artifacts: project context, PRDs, architecture notes, stories, implementation, and review.
+Use BMAD when the work needs product shaping and brainstorming before it needs code: project context, PRDs, architecture notes, and stories.
 
 Start with help:
 
@@ -275,9 +275,9 @@ Then generate the project context:
 /bmad-generate-project-context
 ```
 
-Review the configured BMAD output folder, commonly `_bmad-output/`. Its `project-context.md` should capture the stack, versions, folder conventions, test commands, styling rules, and implementation constraints that the agents should follow.
+Open the BMAD output folder, by default `_bmad-output/`, and read `project-context.md`. It should name the stack, versions, folder conventions, test commands, styling rules, and implementation constraints.
 
-Edit this file before implementation if it misses a rule the project depends on. Remove generic advice that does not change how this project should be built.
+Edit this file before implementation if it misses a rule the project depends on. Remove any generic advice that does not change how this project should be built.
 
 For a complex or poorly documented app, run:
 
@@ -287,7 +287,7 @@ For a complex or poorly documented app, run:
 
 Use that when BMAD needs a current-state project document before planning changes.
 
-### 2. Pick Quick Dev or the Full Method
+### 2. Pick Quick Dev or Product Flow
 
 For a small fix, refactor, or narrow feature:
 
@@ -298,12 +298,25 @@ For a small fix, refactor, or narrow feature:
 Give it the same kind of constrained existing-codebase task you would give a developer:
 
 ```text
-Use the existing Settings table patterns to add a Test action to each collector row.
-Do not change backend routes, database schema, or collector configuration format.
-Run the existing frontend checks before summarizing.
+Goal:
+Add a Refresh Feed button to each source row on the News Sources page.
+
+Likely area:
+News Sources table, source row actions, existing feed refresh API helper, related frontend tests.
+
+Hard limits:
+Do not change feed parsing, database schema, auth rules, or source configuration format.
+
+Patterns to follow:
+Use the existing table action pattern, button styling, loading state, and error handling.
+Use the existing API helper instead of creating a second fetch path.
+
+Verify:
+Run npm test and npm run lint.
+Manually check that refreshing a source updates the row status and does not delete existing articles.
 ```
 
-For larger product work, use the full BMAD path. In this page, that means generating project context first, then running the product/story flow:
+For larger product work, generate project context first, then run the product/story flow:
 
 ```text
 /bmad-brainstorming
@@ -317,9 +330,11 @@ For larger product work, use the full BMAD path. In this page, that means genera
 
 Skip `/bmad-brainstorming` when the change is already defined and you do not need idea exploration.
 
-### 3. Keep BMAD Grounded in Existing Patterns
+After BMAD has shaped the work, you can hand the reviewed brief, PRD, architecture notes, or story to GSD for implementation and verification.
 
-Before accepting a story or implementation, check that the artifact names the existing modules, contracts, and tests it will preserve.
+### 3. Keep BMAD Inside the Existing App
+
+Before accepting a story, check that it names the existing modules, contracts, and tests it will preserve.
 
 If BMAD proposes a modernization you did not ask for, stop and restate the boundary:
 
@@ -327,7 +342,7 @@ If BMAD proposes a modernization you did not ask for, stop and restate the bound
 Keep this as an existing-codebase change. Follow the existing service/component pattern even if a different architecture would be cleaner. Do not rewrite unrelated files.
 ```
 
-After review, continue with implementation:
+If you choose to stay in BMAD for implementation, review the story first, then run:
 
 ```text
 /bmad-dev-story
@@ -338,13 +353,13 @@ After review, continue with implementation:
 
 BMAD writes working files under its configured output folder, commonly `_bmad-output/`. Treat those files as working material, not permanent documentation by default.
 
-Promote or rewrite an artifact into your normal docs only when it records a long-term decision. Otherwise, review it, use it for the change, and keep the PR focused on the product/code diff.
+Move BMAD output into your normal docs only when it records a long-term decision. Otherwise, review it, use it for the change, and keep the PR focused on the product/code diff.
 
 ## Final Review Checklist
 
 Before shipping the change, confirm:
 
-- Generated context, plans, stories, or reviews were read and corrected.
+- Context files, plans, stories, or reviews were read and corrected.
 - Tests, lint, build, and manual checks from the guardrail block were rerun.
 - The diff is limited to the expected files and behavior.
 - No hard-limit files, schemas, APIs, or contracts changed without approval.
@@ -353,7 +368,7 @@ Before shipping the change, confirm:
 
 ## Official References
 
-Official references worth reading alongside this page:
+Read these alongside this page:
 
 | Tool | Reference |
 | --- | --- |
@@ -363,7 +378,7 @@ Official references worth reading alongside this page:
 | BMAD | [Commands and Skills](https://docs.bmad-method.org/reference/commands/) |
 | Claude Code | [Skills and Custom Commands](https://code.claude.com/docs/en/slash-commands) |
 
-Related GSD 2 reading: [Brownfield Reality](https://getshitdone.help/solo-guide/brownfield/) and [Context Engineering](https://getshitdone.help/solo-guide/context-engineering/). GSD 2 has useful brownfield concepts, but its command syntax and project structure differ from the GSD workflow shown above.
+Related GSD 2 reading: [Brownfield Reality](https://getshitdone.help/solo-guide/brownfield/) and [Context Engineering](https://getshitdone.help/solo-guide/context-engineering/). GSD 2 covers brownfield concepts, but its command syntax and project structure differ from the GSD workflow shown above.
 
 ---
 

--- a/content/docs/existing-codebase-workflows.md
+++ b/content/docs/existing-codebase-workflows.md
@@ -16,7 +16,7 @@ Changing an existing app is different from starting with a blank repo. The agent
 There are four levels:
 
 - **Plain session**: use Claude Code or Codex directly for a typo, copy edit, simple test update, or one-file fix where you already know the right file and expected diff.
-- **Quick workflow**: use GSD quick or BMAD quick-dev when the change is small but still needs repo discovery, guardrails, or light tracking.
+- **Quick workflow**: use `gsd-quick` or `bmad-quick-dev` when the change is small but still needs repo discovery, guardrails, or light tracking.
 - **Full GSD path**: use GSD's map, project, spec, discuss, plan, execute, verify, review, and ship flow when the work should be tracked through phases and verification.
 - **Full BMAD path**: use BMAD's project-context, brief, PRD, architecture, story, implementation, and review flow when the work needs product/team-style artifacts.
 
@@ -106,7 +106,7 @@ Manually check that pausing a source updates the row state and does not delete e
 | Situation | Better fit |
 | --- | --- |
 | Typo, copy edit, obvious one-file fix | Plain Claude Code or Codex |
-| Small bug fix with light tracking | GSD quick or BMAD quick-dev |
+| Small bug fix with light tracking | `gsd-quick` or `bmad-quick-dev` |
 | Existing app needs phased delivery and verification | Full GSD path |
 | Product-heavy change with PRD, architecture, stories, and review | BMAD |
 | Team wants durable phase state in git | Full GSD path |

--- a/content/docs/existing-codebase-workflows.md
+++ b/content/docs/existing-codebase-workflows.md
@@ -73,11 +73,11 @@ git switch -c feature/my-change
 
 If `git status --short` prints anything, commit, stash, or move the work to a separate worktree before starting. Dirty changes follow you onto a new branch.
 
-2. Check current project instructions and baseline docs that already exist (if any).
+1. Check current project instructions and baseline docs that already exist (if any).
 
 Check files such as `CLAUDE.md`, `AGENTS.md`, `README.md`, architecture notes, and nearby feature docs. Keep persistent agent instructions short and specific. Do not turn `CLAUDE.md` or `AGENTS.md` into a generated codebase summary. For examples, see [CLAUDE.md and AGENTS.md](agentic-coding-in-terminal#claudemd-and-agentsmd).
 
-3. Run the baseline checks.
+1. Run the baseline checks.
 
 ```bash
 # Examples only. Use the commands from the repo you are working in.
@@ -87,11 +87,11 @@ npm run lint
 
 If the baseline already fails, record the failure before asking the agent to work. That gives you something to compare against after implementation.
 
-4. Start a fresh agent session for the change.
+1. Start a fresh agent session for the change.
 
 Reusing a long or unrelated session makes it easier for old assumptions to leak into the work.
 
-5. Write the task in one or two sentences.
+1. Write the task in one or two sentences.
 
 A good existing-codebase task names the user-facing change, likely files or areas, hard limits, and verification command.
 
@@ -354,6 +354,65 @@ If you choose to stay in BMAD for implementation, review the story first, then r
 BMAD writes working files under its configured output folder, commonly `_bmad-output/`. Treat those files as working material, not permanent documentation by default.
 
 Move BMAD output into your normal docs only when it records a long-term decision. Otherwise, review it, use it for the change, and keep the PR focused on the product/code diff.
+
+## Hands-on Lab: Same Feature, Both Workflows
+
+Run the same feature through GSD and BMAD on the same sample app. The point is to experience the difference, not just read about it.
+
+### Sample Codebase
+
+Use [`fastapi/full-stack-fastapi-template`](https://github.com/fastapi/full-stack-fastapi-template). MIT-licensed, actively maintained, and feels like a real enterprise app instead of a starter shell:
+
+- **Frontend:** React + TypeScript + Vite + Tailwind + shadcn/ui
+- **Backend:** FastAPI + SQLModel + PostgreSQL
+- **Auth:** JWT, password recovery, role-based access
+- **Tests:** Pytest backend + Playwright frontend
+- **Tooling:** Docker Compose, GitHub Actions CI
+
+Different stack? The workflow lessons still transfer. Run the lab here first, then apply the same flow to your own repo.
+
+### Feature: Item Categories with Filter
+
+**Add item categories with a filter on the items list.** It touches:
+
+- **Frontend:** category dropdown on the create/edit form, filter dropdown on the list, category badge on each row
+- **Backend:** category model, CRUD endpoints, a query parameter to filter items
+- **Database:** migration for a `categories` table and a foreign key on `items`
+
+The spread is deliberate. This size of feature surfaces the common brownfield failure modes: scope myopia (don't refactor the items module), AI slop (no premature abstraction), pattern adherence (use the existing CRUD pattern), and migration discipline (handle existing rows).
+
+Write a guardrail block using the shape from [Existing-Codebase Rule](#existing-codebase-rule). Hard limits: don't touch the auth model, don't refactor the items module, don't change unrelated endpoints.
+
+### Run It Through GSD
+
+Two paths:
+
+| Path | Use when |
+| --- | --- |
+| Short path | 20-25 min via `/gsd-quick`. |
+| Full path | Practice map, project init, spec, discuss, plan, execute, verify, review, ship. |
+
+What you should notice:
+
+- The auto-verifier catches "compiles but doesn't satisfy spec" without re-prompting.
+- Phase boundaries and `.planning/` keep a category addition from sprawling into an items-module rewrite.
+- `/gsd-verify-work` is where you confirm the feature actually does what you wanted — not just that tests pass. Tests go green and the spec can still be wrong.
+
+### Run It Through BMAD
+
+Same feature, BMAD this time.
+
+| Path | Use when |
+| --- | --- |
+| Short path | 30-40 min via `/bmad-quick-dev`. |
+| Full path | Full method: PRD, architecture, epics, stories, sprint planning, dev story, code review. |
+
+What you should notice:
+
+- **Win:** brainstorming the category model surfaces decisions a solo prompt skips — per-user vs global, single vs multi-category, soft-delete vs hard-delete. The architecture step catches the migration tradeoff (default category vs nullable FK) before code locks it in.
+- **Cost:** manual verification gates between `/bmad-create-story`, `/bmad-dev-story`, and `/bmad-code-review`. After GSD's auto-verifier, doing it by hand at every step is slow.
+
+After running both, most people land in the same place: BMAD for upstream shaping, GSD for downstream execution.
 
 ## Final Review Checklist
 

--- a/content/docs/skills-plugins-deep-dive.md
+++ b/content/docs/skills-plugins-deep-dive.md
@@ -15,17 +15,100 @@ The examples below are intentionally selective. Star counts, launch claims, and 
 
 ---
 
-## Why skills and plugins matter
+## Why *Good* skills and plugins matter
 
 Plain prompting works for small, clear tasks. It gets weaker when the task needs planning, repeated checks, project memory, or a specific output format.
 
-Skills and plugins help by narrowing the job. They can tell Claude what to inspect, what to ask, which checks to run, and what output format to produce.
+Skills and plugins help by *"spec-ing"* the job. They can tell Claude what to inspect, what to ask, which checks to run, and what output format to produce.
 
 They don't make the model reliable on their own, but they give it clearer rules and more chances to catch mistakes before you treat the output as finished.
 
+When using such agentic coding tools on both brownfield work (with existing codebases) and production-grade greenfield work (not just a POC), some common failures keep showing up:
+
+- **Attempts to refactor legacy code** that the agent was not tasked to refactor or touch in the current session.
+- **AI sloppy code**, including but not limited to:
+  - over-abstraction (e.g. wrapping a single function call in a factory plus interface):
+
+    ```python
+    from abc import ABC, abstractmethod
+
+    class GreeterInterface(ABC):
+        @abstractmethod
+        def greet(self, name: str) -> str: ...
+
+    class DefaultGreeter(GreeterInterface):
+        def greet(self, name: str) -> str:
+            return f"Hello, {name}"
+
+    class GreeterFactory:
+        @staticmethod
+        def create() -> GreeterInterface:
+            return DefaultGreeter()
+
+    greeting = GreeterFactory.create().greet("Alice")
+    # When `def greet(name): return f"Hello, {name}"` was all that was needed.
+    ```
+
+  - lasagna code (e.g. several thin pass-through layers between the handler and the real logic):
+
+    ```python
+    def handle_request(req):
+        return _process_request(req)
+
+    def _process_request(req):
+        return _execute_request(req)
+
+    def _execute_request(req):
+        return _run_request(req)
+
+    def _run_request(req):
+        return {"user_id": req["user_id"]}
+    # Four layers of pass-through to return one field.
+    ```
+
+  - defensive coding theater (e.g. null checks on values the type system already guarantees are non-null, try/catch around code that cannot throw):
+
+    ```python
+    def total(items: list[int]) -> int:
+        if items is None:           # type signature already guarantees list[int]
+            return 0
+        try:
+            return sum(items)       # sum() over list[int] cannot throw
+        except Exception:
+            return 0
+    ```
+
+  - boilerplate bloat (e.g. docstrings and getters/setters on trivial fields):
+
+    ```python
+    class User:
+        def __init__(self, name: str):
+            self._name = name
+
+        @property
+        def name(self) -> str:
+            """Return the user's name."""
+            return self._name
+
+        @name.setter
+        def name(self, value: str) -> None:
+            """Set the user's name."""
+            self._name = value
+    # A @dataclass or plain attribute would do the same work.
+    ```
+
+- **Vacuous or tautological tests** that mock every internal call, so the tests pass without actually checking anything.
+- **Scope failure** where the agent refuses an obvious boy-scout fix because it didn't cause the issue this session.
+
+These aren't smartness problems. They're enforcement gaps — nothing makes the agent push back on itself. The fix is friction: a checklist it has to run, a verifier it has to pass, a phase boundary it can't quietly skip.
+
+We call this *bounded autonomy*: enough room to do the work, with guardrails that catch the specific ways it drifts.
+
+Plain prompting is unbounded. A skill tightens the bound. A framework like BMAD or GSD tightens it more.
+
 ---
 
-## Skills vs plugins
+## Skills vs Plugins
 
 Skills are folders with a `SKILL.md` file. The file describes when the skill should load and what Claude should do once it loads. Larger examples, scripts, templates, or references can live beside it.
 
@@ -39,21 +122,41 @@ skill-name/
   assets/           # Optional templates or static files
 ```
 
+The difference matters for how much enforcement each one can carry. Think of it as a spectrum:
+
+- A **skill** is mostly instructions. It tells Claude what to do when it loads. The agent can still ignore parts of it or treat it as a hint.
+- A **plugin** can add hooks, subagents, and commands that run regardless of what the agent decides. Hooks in particular are enforcement: they fire whether or not the agent wanted them to.
+- A **framework** like BMAD or GSD goes further. It writes project state to disk (PRDs, plans, phases, verification reports), so each step leaves artifacts the next agent reads, and the workflow becomes hard to skip past.
+
 ---
 
 ## Creating your own skills
 
 Custom skills are often more useful than public ones because they encode your team's real habits.
 
-Good candidates include:
+Potentially Good skills include:
 
-- PR review rules
+- Specific Team PR review rules
 - release checklists
 - database migration patterns
-- incident response steps
 - design system rules
 - security review requirements
 - report or document templates
+
+### When should you create a skill
+
+Before writing a skill, the useful question to ask is: what is the lightest enforcement layer the agent cannot quietly skip past? There are roughly four to choose from, and a skill is only one of them.
+
+| Layer | What it is | What it catches |
+| --- | --- | --- |
+| **CLAUDE.md** | Always-on rules and conventions for the project | Background context loaded into every session — e.g. "this repo uses Bun, not Node" |
+| **Skill** | Folder that loads when triggered by a description match | Multi-step workflows or checklists that only matter for specific tasks |
+| **Hook** | Mechanical command that fires on tool use or session events | Anything you need enforced regardless of what the agent decides — formatters, type checks, secret scanning |
+| **Task scope** | Per-job instructions in the prompt or task brief | One-off constraints that do not generalize across sessions |
+
+The general drift we have found: if the rule must apply every time and the agent might rationalize skipping it, put it in a hook. If the rule needs context and only fires on certain tasks, put it in a skill. If the rule is project-wide background, put it in CLAUDE.md. If the rule is purely for the current job, keep it in the prompt.
+
+A skill is the right fit when the rule sits between always-on (too noisy for every session) and per-job (too easily forgotten across sessions).
 
 ### Skill anatomy
 
@@ -159,7 +262,7 @@ The document skills help Claude create and edit real office files:
 - `pptx` for slide decks
 - `xlsx` for spreadsheets
 
-Use these when the output needs to open cleanly in another application. If the user only needs a short answer or table in chat, do not add file generation.
+Use these when the stakeholder expects a Word doc, slide deck, or styled PDF. For internal docs (design notes, ADRs, runbooks, status reports), markdown is better: it reviews in PRs, diffs cleanly, and lives next to the code.
 
 ### Install
 
@@ -440,6 +543,16 @@ Execution is plan-based. GSD splits a phase into plans, groups independent plans
 
 This is useful when a phase has several separable parts. It is less useful when the change is one file or one obvious bug fix.
 
+### Two layers of verification
+
+GSD verifies work in two layers, not one.
+
+**Layer 1: in-loop code verifier (automatic).** During `/gsd-execute-phase`, a code verifier agent checks the work as it lands. If the implementation does not meet the plan, the execution loops — fix, re-verify, repeat — until the spec is met. This catches "agent claimed done but it isn't."
+
+**Layer 2: `/gsd-verify-work` (human UAT).** Once the in-loop verifier passes, `/gsd-verify-work` walks you through the feature to confirm it behaves the way you envisioned. The agent's "spec met" is not the user's "feature delivered."
+
+Together: **structured human-in-the-loop, not human-eliminated.** Layer 1 catches agent self-deception. Layer 2 catches the spec-vs-vision gap.
+
 ### When to use it
 
 Use GSD when you want a project or feature built in deliberate phases. It is a good fit for solo developers and small teams that want structure without a full agile process.
@@ -455,6 +568,15 @@ BMAD and GSD use their output folders differently.
 GSD treats `.planning/` as project state. By default, its planning docs are meant to be committed unless you choose a private setup. If `.planning/` contains secrets, private notes, or throwaway plans, set `planning.commit_docs: false` and add `.planning/` to `.gitignore`. Check `.planning/config.json` first if you configured search or API integrations.
 
 BMAD's `_bmad-output/` is more of a working folder. Keep files that still guide the project, especially `project-context.md`, but do not assume every PRD, story, or review artifact belongs in git forever. When an artifact becomes long-term project documentation, move or rewrite it into your normal docs folder.
+
+### Why this matters for production
+
+Treat `.planning/` and `_bmad-output/` as **the agentic decision log** — the audit trail for why the code looks the way it does. Six months from now, "Claude wrote it" is not a maintenance answer; the PRD, the discussion notes, the plan, and the verification report are.
+
+Two practical consequences:
+
+- Commit `.planning/` by default for production work — it survives team turnover, and the next engineer can read decisions instead of guessing them.
+- Include `.planning/` in PR review. The diff is half the change; the plan and verification report are the other half, and that is where scope, assumptions, and tradeoffs live.
 
 ---
 
@@ -488,7 +610,9 @@ The Codex plugin lets Claude Code call Codex for review or delegated work. A sec
 
 ### When to use it
 
-Use the plugin after a larger change, before shipping, or when Claude is stuck on a bug. Ask for a narrow review target:
+Use the plugin after a larger change, before shipping, or when Claude is stuck on a bug. Using a second model from another provider, which has different training data, can help to provide newer insights and find bugs that the same model checking itself might miss.
+
+Ask for a narrow review target:
 
 ```text
 /codex:adversarial-review look for missed auth checks and unsafe database writes
@@ -500,17 +624,17 @@ Treat the second model's output as another review input, not as approval.
 
 ## Hands-on workshops
 
-Use these exercises after the sections above. This page helps you pick a lab. The step-by-step commands live in the hands-on repo so this page does not go stale every time the labs change.
+Use these exercises after the sections above. Each lab is designed to make a specific insight *felt*, not just read. The step-by-step commands live in the hands-on repo so this page does not go stale every time the labs change.
 
 **Workshop repo:** [stcomiin/claude-docs-workshop-handson](https://github.com/stcomiin/claude-docs-workshop-handson)
 
-| Workshop | Time | Good for | Guide |
+| Workshop | Time | What it demonstrates | Guide |
 | --- | --- | --- | --- |
-| Research report generation | 20-30 minutes | Subagents, web research, and document skills | [Starter workspace](https://github.com/stcomiin/claude-docs-workshop-handson/tree/main/research-report-generation-workflow-starter) |
-| Existing app with GSD | 25-60 minutes | Codebase mapping, quick tasks, and full GSD phase flow | [GSD workshop](https://github.com/stcomiin/claude-docs-workshop-handson/tree/main/one-shot-task-dashboard-gsd-workshop) |
-| Existing app with BMAD | 35-75 minutes | Project context, quick-dev, planning files, and review | [BMAD workshop](https://github.com/stcomiin/claude-docs-workshop-handson/tree/main/one-shot-task-dashboard-bmad-workshop) |
+| Research report generation | 20-30 minutes | Subagents, web research, and document skills — skills are more than prompt snippets | [Starter workspace](https://github.com/stcomiin/claude-docs-workshop-handson/tree/main/research-report-generation-workflow-starter) |
+| Existing app with GSD | 25-60 minutes | Scope control on a real codebase via codebase mapping, phase boundaries, and auto-verification | [Hands-on Lab → GSD](existing-codebase-workflows#run-it-through-gsd) |
+| Existing app with BMAD | 35-75 minutes | Same app and feature as the GSD lab — feel where BMAD's brainstorming pays off and where the manual dev gates slow you down | [Hands-on Lab → BMAD](existing-codebase-workflows#run-it-through-bmad) |
 
-If you are running a live session, pin the workshop repo to a known commit or tag. If you want the newest version, follow the README in each workshop folder.
+The existing-app labs are run against [`fastapi/full-stack-fastapi-template`](https://github.com/fastapi/full-stack-fastapi-template) directly, fork or clone it before the session.
 
 <span id="-workshop-exercise-research-and-report-generation-workflow"></span>
 
@@ -529,33 +653,16 @@ Review the result by asking:
 - Do the generated files open cleanly?
 - Did the slide deck become a briefing, not a copied report?
 
-### Existing app with GSD
+### Existing app with GSD or BMAD
 
-This lab uses GSD on a small existing OSINT dashboard instead of a blank project.
+The hands-on lab for using GSD and BMAD on a real existing codebase — same sample app, same feature, both workflows — lives in [Existing Codebase Workflows: Hands-on Lab](existing-codebase-workflows#hands-on-lab-same-feature-both-workflows). It is structured as the practice counterpart to the GSD and BMAD step-by-step in that doc.
 
-The feature is deliberately small: add a **Test** action to each collector row in Settings. The backend route and API helper already exist. The work is finding the right path through the codebase and exposing the missing UI without changing the backend or database.
+The lab covers:
 
-The [GSD workshop](https://github.com/stcomiin/claude-docs-workshop-handson/tree/main/one-shot-task-dashboard-gsd-workshop) has two paths:
-
-| Path | Use when |
-| --- | --- |
-| Short path | You want a 20-25 minute exercise using `$gsd-quick`. |
-| Full path | You want to practice map, project init, spec, discuss, plan, execute, verify, and review. |
-
-The main lesson is scope control. GSD is useful here because it finds the existing project structure, captures assumptions, and keeps a small UI change from turning into a rewrite.
-
-### Existing app with BMAD
-
-This lab uses the same dashboard feature as the GSD workshop, but runs it through BMAD. That makes the comparison useful: same app, same feature, different workflow.
-
-Use the [BMAD workshop](https://github.com/stcomiin/claude-docs-workshop-handson/tree/main/one-shot-task-dashboard-bmad-workshop) when you want participants to see how BMAD uses project context, quick-dev, PRDs, architecture notes, stories, implementation, and review.
-
-| Path | Use when |
-| --- | --- |
-| Short path | You want a 30-40 minute exercise using `bmad-quick-dev`. |
-| Full path | You want to practice the fuller BMAD method: PRD, architecture, epics or stories, sprint planning, dev story, and code review. |
-
-BMAD is useful when you want product-team-style planning before code: PRD, architecture, stories, implementation, and review. GSD carries context too, but it is organized around phases, executable plans, parallel implementation, and verification.
+- The sample codebase pick ([`fastapi/full-stack-fastapi-template`](https://github.com/fastapi/full-stack-fastapi-template))
+- The feature scope (item categories with filter — touches frontend, backend, and a database migration)
+- Why this feature surfaces real brownfield discipline (scope control, AI slop prevention, pattern adherence, migration discipline)
+- Two paths per workflow (short via `/gsd-quick` or `/bmad-quick-dev`, full via the complete phase or product flow)
 
 ---
 

--- a/content/docs/skills-plugins-deep-dive.md
+++ b/content/docs/skills-plugins-deep-dive.md
@@ -258,6 +258,8 @@ After installation, open Claude Code in the project and run:
 /bmad-help
 ```
 
+Newer BMAD installs may expose these as skills instead of slash commands. In that setup, type `bmad-help`; the workflow names are otherwise the same.
+
 ### Modules
 
 BMAD installs modules. Start with BMad Method unless you know you need a specialized track.
@@ -329,6 +331,8 @@ For larger product work, use the planning path:
 /bmad-code-review
 ```
 
+For a step-by-step brownfield workflow, see [Existing Codebase Workflows](/docs/existing-codebase-workflows/).
+
 ### What to look for
 
 BMAD is working well when each step produces a concrete artifact: a brief, PRD, architecture note, story, implementation, or review. Those artifacts make decisions easier to audit later.
@@ -373,6 +377,8 @@ If the repo already has code, map it before starting a new project:
 ```
 
 This gives GSD a first pass at the stack, architecture, conventions, and risk areas. It is more useful than asking project-init questions against an unknown codebase.
+
+For a step-by-step brownfield workflow, see [Existing Codebase Workflows](/docs/existing-codebase-workflows/).
 
 ### Typical flow for a phase
 

--- a/content/docs/skills-plugins-deep-dive.md
+++ b/content/docs/skills-plugins-deep-dive.md
@@ -331,7 +331,7 @@ For larger product work, use the planning path:
 /bmad-code-review
 ```
 
-For a step-by-step brownfield workflow, see [Existing Codebase Workflows](/docs/existing-codebase-workflows/).
+For a step-by-step brownfield workflow, see [Existing Codebase Workflows](existing-codebase-workflows).
 
 ### What to look for
 
@@ -378,7 +378,7 @@ If the repo already has code, map it before starting a new project:
 
 This gives GSD a first pass at the stack, architecture, conventions, and risk areas. It is more useful than asking project-init questions against an unknown codebase.
 
-For a step-by-step brownfield workflow, see [Existing Codebase Workflows](/docs/existing-codebase-workflows/).
+For a step-by-step brownfield workflow, see [Existing Codebase Workflows](existing-codebase-workflows).
 
 ### Typical flow for a phase
 

--- a/content/docs/skills-plugins-deep-dive.md
+++ b/content/docs/skills-plugins-deep-dive.md
@@ -97,14 +97,53 @@ When using such agentic coding tools on both brownfield work (with existing code
     # A @dataclass or plain attribute would do the same work.
     ```
 
-- **Vacuous or tautological tests** that mock every internal call, so the tests pass without actually checking anything.
+- **Vacuous or tautological tests** (e.g. mocking every internal call so the test only verifies that the mocks were called):
+
+    ```python
+    def test_double():
+        calc = Mock()
+        calc.double.return_value = 10
+        assert calc.double(5) == 10
+    ```
+
 - **Scope failure** where the agent refuses an obvious boy-scout fix because it didn't cause the issue this session.
 
-These aren't smartness problems. They're enforcement gaps — nothing makes the agent push back on itself. The fix is friction: a checklist it has to run, a verifier it has to pass, a phase boundary it can't quietly skip.
+    ```python
+    # Task: "Return None for missing users instead of letting db.find_user throw exception."
+    
+    # Before
+    def get_user(user_id):
+        cached = cache.get(f"user:{user_id}")
+        if cached is not None:
+            return cached
+        
+        user = db.find_user(user_id)                       # raises UserNotFound if missing, to be fixed
+        cache.set(f"users:{user_id}", user, ttl=3600)
+        return user
+
+    # After
+    def get_user(user_id):
+        cached = cache.get(f"user:{user_id}")
+        if cached is not None:
+            return cached
+        
+        try:
+            user = db.find_user(user_id)
+        except UserNotFound:
+            return None                                    # changed by agent
+        cache.set(f"users:{user_id}", user, ttl=3600)      # typo, pre-existing: "users:" vs "user:"
+        return user
+    
+    # Agent: "The cache.set key looks off but it's pre-existing — out of scope."
+    # Result: the function appears to work perfectly. It just has a 0% cache hit rate,
+    # hammering the database on every call.
+
+    ```
+This is not a "model is not smart enough" problem. We need to build our "harness" or setup around the model with intentional guardrails that guide it toward what we want.
 
 We call this *bounded autonomy*: enough room to do the work, with guardrails that catch the specific ways it drifts.
 
-Plain prompting is unbounded. A skill tightens the bound. A framework like BMAD or GSD tightens it more.
+Plain prompting is unbounded. A skill tightens it, and frameworks like BMAD or GSD tighten it more.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add a dedicated Existing Codebase Workflows docs page for brownfield GSD and BMAD usage
- Link the new workflow page from the GSD and BMAD deep-dive sections
- Update the README page list for the new docs page

## Verification
- `docker run --rm -v "$(pwd):/src" -w /src hugomods/hugo:exts hugo --gc --minify`
- `git diff --check`

Closes #5