### PR TITLE
fix: stop pinning llms.txt banner on mobile scroll

### DIFF
--- a/layouts/partials/custom/head-end.html
+++ b/layouts/partials/custom/head-end.html
@@ -152,6 +152,14 @@
   .llms-banner-copy[disabled] {
     opacity: 0.7;
   }
+  /* Hextra pins the banner to the top on mobile (hx:max-md:sticky), where it
+     overlaps the hero on scroll. Match the desktop behavior and let it scroll
+     away with the page. */
+  @media (max-width: 767px) {
+    .hextra-banner {
+      position: static !important;
+    }
+  }
 </style>
 
 <script>


### PR DESCRIPTION
Hextra's banner partial applies hx:max-md:sticky to .hextra-banner, which
made it overlap the hero on mobile while scrolling. Override with
position: static below the md breakpoint so it matches the desktop
behavior and scrolls away with the page.